### PR TITLE
Misc/cleanup - force tostring on cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Form input parameters for configuring a bundle for deployment.
   - **`data_volume_size`** *(integer)*: The size of the TimescaleDB's data storage. Minimum: `10`. Maximum: `1000`. Default: `10`.
   - **`delete_volumes_on_destroy`** *(boolean)*: If set to false and this bundle is destroyed, the volumes will be left behind. See operator guide for more information. Default: `False`.
   - **`memory_limit`** *(number)*: The amount of memory (in GiB) made available to your TimescaleDB deployment by kubernetes. Minimum: `0.5`. Maximum: `64`. Default: `4`.
-- **`namespace`** *(string)*: Choose a namespace for Timescale DB.
+- **`namespace`** *(string)*: Choose a namespace for Timescale DB. Default: `default`.
 ## Examples
 
   ```json

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -37,6 +37,7 @@ params:
       title: Namespace
       description: Choose a namespace for Timescale DB.
       pattern: "^[a-z]{1,}[a-z0-9-]{0,62}$"
+      default: default
       message:
         pattern: Namespace can only contain lowercase letters, numbers, and hyphens, with a max of 63 characters.
     database_configuration:

--- a/src/helm_values.tf
+++ b/src/helm_values.tf
@@ -17,7 +17,7 @@ locals {
         memory = "${var.database_configuration.memory_limit}Gi"
       }
       limits = {
-        cpu    = "${var.database_configuration.cpu_limit}"
+        cpu    = tostring(var.database_configuration.cpu_limit)
         memory = "${var.database_configuration.memory_limit}Gi"
       }
     }

--- a/src/helm_values.tf
+++ b/src/helm_values.tf
@@ -13,7 +13,7 @@ locals {
 
     resources = {
       requests = {
-        cpu    = "${var.database_configuration.cpu_limit}"
+        cpu    = tostring(var.database_configuration.cpu_limit)
         memory = "${var.database_configuration.memory_limit}Gi"
       }
       limits = {


### PR DESCRIPTION
Without `tostring` 
<img width="1036" alt="Screenshot 2022-11-01 at 2 05 03 PM" src="https://user-images.githubusercontent.com/651833/199341108-8aa79413-c6f9-448b-9319-99287e5d5be7.png">

With `tostring`
<img width="1445" alt="Screenshot 2022-11-01 at 2 05 20 PM" src="https://user-images.githubusercontent.com/651833/199341167-6a159d42-bbac-48c6-afc3-eeac2adbe216.png">
